### PR TITLE
Make it possible to parse all printable utf chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ A golang wrapper for parsing gocui keybindings.
 ```go
 // get a single keybinding
 keybinding.Parse("ctrl+c")
+keybinding.Parse("/")
+keybinding.Parse("ü")
+keybinding.Parse("ö")
 
 // get a list of keybindings
 keybinding.ParseAll("ctrl+A, ctrl+B, CTRL+ALT+C")

--- a/keybinding.go
+++ b/keybinding.go
@@ -127,9 +127,9 @@ func Parse(input string) (Key, error) {
 	f := func(c rune) bool { return unicode.IsSpace(c) || c == '+' }
 	tokens := strings.FieldsFunc(input, f)
 
-	if len(tokens) == 1 && len(tokens[0]) == 1 {
-		single := rune(tokens[0][0])
-		if unicode.IsLetter(single) {
+	if len(tokens) == 1 && len([]rune(tokens[0])) == 1 {
+		single := []rune(tokens[0])[0]
+		if unicode.IsPrint(single) {
 			return Key{single, gocui.ModNone, tokens}, nil
 		}
 	}

--- a/keybinding_test.go
+++ b/keybinding_test.go
@@ -36,6 +36,9 @@ func TestParse(t *testing.T) {
 		{"ctrl + alt + !", 0, gocui.ModAlt, "unsupported keybinding: KeyCtrl! (+1)"},
 		{"q", rune('q'), gocui.ModNone, ""},
 		{" q", rune('q'), gocui.ModNone, ""},
+		{"ü", rune('ü'), gocui.ModNone, ""},
+		{"ö", rune('ö'), gocui.ModNone, ""},
+		{"/", rune('/'), gocui.ModNone, ""},
 	}
 
 	for idx, trial := range table {


### PR DESCRIPTION
I was trying to make keybindings like `ö`, `ü`, `/` work in [dive](https://github.com/wagoodman/dive) . Because UTF characters may consist of more than one byte, I converted tokens to a rune array to accurately determine the size of each token

**For example `ö` is 2 byte and string length is 2 but rune length is 1**

Also I changed `IsLetter` check to `IsPrint` to parse special characters.

With this pull request, it will be possible to solve wagoodman/dive#129 and wagoodman/dive#415 issues.